### PR TITLE
Apply `na_if()` to numeric columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(person(c("Lacey", "W."), "Heinsberg", email = "law145@pitt.edu", ro
 URL: https://lwheinsberg.github.io/dbGaPCheckup/, https://github.com/lwheinsberg/dbGaPCheckup
 Description: Contains functions that check for formatting of the Subject Phenotype data set and data dictionary as specified by the National Center for Biotechnology Information (NCBI) Database of Genotypes and Phenotypes (dbGaP) <https://www.ncbi.nlm.nih.gov/gap/docs/submissionguide/>. 
 Imports: 
-    readxl, tidyr, dplyr, formatR, ggplot2, pander, magrittr, rmarkdown, purrr, questionr, tibble, rlang, labelled, stats, utils, graphics
+    readxl, tidyr, dplyr, formatR, ggplot2, pander, magrittr, rmarkdown, purrr, questionr, tibble, rlang, labelled, stats, utils, graphics, tidyselect
 License: GPL-2 
 Encoding: UTF-8
 LazyData: true

--- a/R/create_report.R
+++ b/R/create_report.R
@@ -9,7 +9,7 @@
 #' @param non.NA.missing.codes A user-defined vector of numerical missing value codes (e.g., -9999).
 #' @param output.path Path to the folder in which to create the HTML report document.
 #' @param open.html If TRUE, open the HTML report document in the web browser.
-#' @param fn.stem File name stem. 
+#' @param fn.stem File name stem.
 #' @return Full path to the HTML report document.
 #' @export
 #' @import pander
@@ -27,13 +27,13 @@
 #' }
 
 create_report <- function(DD.dict, DS.data, sex.split = FALSE, sex.name = NULL, start = 1, end = 1, non.NA.missing.codes=NA, output.path = tempdir(), open.html = TRUE, fn.stem="Report") {
-  
-  # Temporarily remove any entries in the VALUES columns that are "INTEGERS", "DECIMALS", OR "STRINGS" 
+
+  # Temporarily remove any entries in the VALUES columns that are "INTEGERS", "DECIMALS", OR "STRINGS"
   col <- which(names(DD.dict)=="VALUES")
   for (i in col:ncol(DD.dict)){
     DD.dict[i][DD.dict[,i]=="INTEGERS" | DD.dict[,i]=="DECIMALS" | DD.dict[,i]=="STRINGS" ] <- NA
   }
-  
+
   # Adjust VALUES column names in the data dictionary
   n <- min(grep("VALUES",names(DD.dict)) + 1)
   n.max <- ncol(DD.dict)
@@ -53,7 +53,8 @@ create_report <- function(DD.dict, DS.data, sex.split = FALSE, sex.name = NULL, 
   # Create a temporary data set based on the specification of non-NA missing value codes
     dataset_na <- DS.data
     for (value in na.omit(non.NA.missing.codes)) {
-      dataset_na <- dataset_na %>% na_if(value)
+      dataset_na <- dataset_na %>%
+        mutate(across(tidyselect::where(is.numeric), ~na_if(.x, value)))
     }
 
   Rmd.file <- system.file("rmd","dbGaP_check_report.Rmd", package="dbGaPCheckup", mustWork = TRUE)

--- a/R/minmax_check.R
+++ b/R/minmax_check.R
@@ -18,7 +18,7 @@
 #' # View out of range values:
 #' details <- minmax_check(DD.dict.A, DS.data.A)$Information
 #' details[[1]]$OutOfRangeValues
-#' # Attempt 2, specifying -9999 and -4444 as missing value 
+#' # Attempt 2, specifying -9999 and -4444 as missing value
 #' # codes so check works correctly
 #' minmax_check(DD.dict.A, DS.data.A, non.NA.missing.codes=c(-9999, -4444))
 #'
@@ -54,12 +54,13 @@ minmax_check <- function(DD.dict, DS.data, verbose=TRUE, non.NA.missing.codes=NA
   } else {
     dataset_na <- DS.data
     for (value in na.omit(non.NA.missing.codes)) {
-      dataset_na <- dataset_na %>% na_if(value)
+      dataset_na <- dataset_na %>%
+        mutate(across(tidyselect::where(is.numeric), ~na_if(.x, value)))
     }
 
     CHECK.combined <- NULL
 
-    for (row in seq_len(nrow(DD.dict))) { 
+    for (row in seq_len(nrow(DD.dict))) {
 
       # Extract the minimum and maximum values for this trait
       range_dictionary <- c(DD.dict$MIN[row],DD.dict$MAX[row])

--- a/R/missingness_summary.R
+++ b/R/missingness_summary.R
@@ -21,7 +21,8 @@ missingness_summary <- function(DS.data, non.NA.missing.codes=NA, threshold=95) 
   # Replace numeric missing codes with NA values
   dataset_na <- DS.data
   for (value in na.omit(non.NA.missing.codes)) {
-    dataset_na <- dataset_na %>% na_if(value)
+    dataset_na <- dataset_na %>%
+      mutate(across(tidyselect::where(is.numeric), ~na_if(.x, value)))
   }
 
   # Calculate missingness summary across variables

--- a/vignettes/dbGaPCheckup_vignette.Rmd
+++ b/vignettes/dbGaPCheckup_vignette.Rmd
@@ -518,7 +518,8 @@ library(dplyr)
 non.NA.missing.codes <- c(-4444, -9999)
 dataset.na <- DS.data
 for (value in na.omit(non.NA.missing.codes)) {
-  dataset.na <- dataset.na %>% na_if(value)
+  dataset.na <- dataset.na %>%
+        mutate(across(tidyselect::where(is.numeric), ~na_if(.x, value)))
 }
 ```
 


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`na_if()` now uses vctrs. It previously accidentally allowed you to apply it to an entire data frame at once, but this was never the actual intention of this function, it is meant to be applied to a single column at a time. Applying it to a data frame like this now errors, so I've updated your usage to correctly apply it to only your numeric columns.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!